### PR TITLE
Make it work (except for dependency injection)

### DIFF
--- a/main/index.ts
+++ b/main/index.ts
@@ -1,11 +1,18 @@
-// import { AzureFunction, Context, HttpRequest } from "@azure/functions"
+import { AzureFunction, Context, HttpRequest } from "@azure/functions"
 const createHandler = require('azure-function-express').createHandler;
 import { createApp } from '../src/main';
 
+const handlerPromise = (async function getHandler() {
+  const app = await createApp();
+  const instance = app.getHttpAdapter().getInstance(); // express app
+  await app.listen(3000);
+  return createHandler(instance);
+})();
 
+const main: AzureFunction = function (context: Context, req: HttpRequest): void {
+  handlerPromise.then(function(handler) {
+    handler(context, req);
+  })
+};
 
-export default async function() {
-    const app = await createApp();
-    const instance = app.getHttpAdapter().getInstance(); // express app
-    return createHandler(instance);
-  }
+export default main;

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -7,6 +7,6 @@ export class AppController {
 
   @Get()
   getHello(): string {
-    return this.appService.getHello();
+    return 'hello';
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,9 +4,3 @@ import { AppModule } from './app.module';
 export async function createApp() {
   return await NestFactory.create(AppModule); 
 }
-
-async function bootstrap() {
-  const app = await createApp();
-  await app.listen(3000);
-}
-bootstrap();


### PR DESCRIPTION
This seems to be the magic line that starts registers the routes:
```js
await app.listen(3000);
```

Looks like `createHandler` doesn't return a promise, which means it uses the non-async style of Azure Functions (i.e., it calls `context.done()` when finished). We need to change the actual Azure Function to non-async so that the handler is able to call `context.done()` (otherwise it'll throw an error)

Wrapped init logic in an async function and capture the promise. Calling `.then()` on the promise in the function ensures that initialization is completed.

Dependency injection appears to be broken, I haven't had a chance to look into it. Hardcoding the value so it works for now.

Removed the `bootstrap()` code as that doesn't do anything in our app. (It's a good thing it was there though because that was what gave me the clues to figure this out!)